### PR TITLE
Add basic cf grammar and parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module cloudpact
+
+go 1.24.3

--- a/parser/grammar/grammar.go
+++ b/parser/grammar/grammar.go
@@ -1,0 +1,127 @@
+package grammar
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/scanner"
+)
+
+// Grammar:
+//   File   := { Model }
+//   Model  := 'model' IDENT '{' { Field } '}'
+//   Field  := IDENT ':' IDENT
+//   Type   := IDENT
+
+// File represents a .cf file consisting of one or more model declarations.
+type File struct {
+	Models []*Model
+}
+
+// Model declares a new model with a name and a list of fields.
+type Model struct {
+	Name   string
+	Fields []*Field
+}
+
+// Field represents a single field within a model.
+type Field struct {
+	Name string
+	Type *Type
+}
+
+// Type of a field. For now it is simply an identifier like Int or String.
+type Type struct {
+	Name string
+}
+
+// Parse reads .cf content from r and returns the parsed AST.
+func Parse(r io.Reader) (*File, error) {
+	p := &parser{}
+	p.scanner.Init(r)
+	p.scanner.Mode = scanner.ScanIdents | scanner.ScanInts | scanner.SkipComments
+	p.next()
+	return p.parseFile()
+}
+
+// ParseString parses a string containing .cf grammar into an AST.
+func ParseString(s string) (*File, error) {
+	return Parse(strings.NewReader(s))
+}
+
+type parser struct {
+	scanner scanner.Scanner
+	tok     rune
+}
+
+func (p *parser) next() {
+	p.tok = p.scanner.Scan()
+}
+
+func (p *parser) parseFile() (*File, error) {
+	file := &File{}
+	for p.tok != scanner.EOF {
+		// Skip any stray semicolons or newlines handled automatically.
+		if p.tok == scanner.EOF {
+			break
+		}
+		m, err := p.parseModel()
+		if err != nil {
+			return nil, err
+		}
+		file.Models = append(file.Models, m)
+	}
+	return file, nil
+}
+
+func (p *parser) expect(tok rune, expected string) error {
+	if p.tok != tok {
+		return fmt.Errorf("expected %s, got %q", expected, p.scanner.TokenText())
+	}
+	p.next()
+	return nil
+}
+
+func (p *parser) parseModel() (*Model, error) {
+	if p.tok != scanner.Ident || p.scanner.TokenText() != "model" {
+		return nil, fmt.Errorf("expected 'model', got %q", p.scanner.TokenText())
+	}
+	p.next()
+	if p.tok != scanner.Ident {
+		return nil, fmt.Errorf("expected model name, got %q", p.scanner.TokenText())
+	}
+	name := p.scanner.TokenText()
+	p.next()
+	if err := p.expect('{', "'{'"); err != nil {
+		return nil, err
+	}
+	model := &Model{Name: name}
+	for p.tok != '}' && p.tok != scanner.EOF {
+		fld, err := p.parseField()
+		if err != nil {
+			return nil, err
+		}
+		model.Fields = append(model.Fields, fld)
+	}
+	if err := p.expect('}', "'}'"); err != nil {
+		return nil, err
+	}
+	return model, nil
+}
+
+func (p *parser) parseField() (*Field, error) {
+	if p.tok != scanner.Ident {
+		return nil, fmt.Errorf("expected field name, got %q", p.scanner.TokenText())
+	}
+	name := p.scanner.TokenText()
+	p.next()
+	if err := p.expect(':', "':'"); err != nil {
+		return nil, err
+	}
+	if p.tok != scanner.Ident {
+		return nil, fmt.Errorf("expected type name, got %q", p.scanner.TokenText())
+	}
+	typ := &Type{Name: p.scanner.TokenText()}
+	p.next()
+	return &Field{Name: name, Type: typ}, nil
+}

--- a/parser/grammar/grammar_test.go
+++ b/parser/grammar/grammar_test.go
@@ -1,0 +1,44 @@
+package grammar
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Test parsing of a model declaration without fields.
+func TestParseModelDeclaration(t *testing.T) {
+	src := `model User {}`
+	file, err := ParseString(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(file.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(file.Models))
+	}
+	if file.Models[0].Name != "User" {
+		t.Fatalf("expected model name 'User', got %q", file.Models[0].Name)
+	}
+}
+
+// Test parsing of fields and types within a model.
+func TestParseFieldsAndTypes(t *testing.T) {
+	src := `
+model User {
+    id: Int
+    name: String
+}
+`
+	file, err := ParseString(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	expected := &File{Models: []*Model{
+		{Name: "User", Fields: []*Field{
+			{Name: "id", Type: &Type{Name: "Int"}},
+			{Name: "name", Type: &Type{Name: "String"}},
+		}},
+	}}
+	if !reflect.DeepEqual(file, expected) {
+		t.Fatalf("expected %#v, got %#v", expected, file)
+	}
+}


### PR DESCRIPTION
## Summary
- define a minimal context-free grammar for `.cf` files and implement an AST-based parser
- expose Parse/ParseString to turn `.cf` text into model/field/type structures
- add unit tests covering model declarations, fields, and types

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f749aa9e8832089083eb74c402749