### PR TITLE
feat: generate TypeScript from OpenAPI spec

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,11 +8,12 @@ import (
 
 	"cloudpact/parser/grammar"
 	"cloudpact/spec/openapi"
+	"cloudpact/tsgen"
 )
 
 func main() {
 	if len(os.Args) < 3 {
-		fmt.Println("Usage: cloudpact gen model <ModelName>\n       cloudpact gen openapi <file.cf>")
+		fmt.Println("Usage: cloudpact gen model <ModelName>\n       cloudpact gen openapi <file.cf>\n       cloudpact gen ts <spec.yaml>")
 		return
 	}
 
@@ -34,6 +35,15 @@ func main() {
 		}
 		cf := os.Args[3]
 		if err := generateOpenAPI(cf); err != nil {
+			fmt.Println("error:", err)
+		}
+	case cmd == "gen" && sub == "ts":
+		if len(os.Args) < 4 {
+			fmt.Println("missing OpenAPI spec file")
+			return
+		}
+		spec := os.Args[3]
+		if err := tsgen.Generate(spec); err != nil {
 			fmt.Println("error:", err)
 		}
 	default:

--- a/tsgen/tsgen.go
+++ b/tsgen/tsgen.go
@@ -1,0 +1,148 @@
+package tsgen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Generate reads an OpenAPI spec in YAML format and emits TypeScript
+// interfaces and a simple API client stub under generated/ts/.
+// The parser understands the limited YAML subset produced by the openapi
+// package in this repository.
+func Generate(specPath string) error {
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		return err
+	}
+	schemas, err := parseSchemas(string(data))
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join("generated", "ts"), 0755); err != nil {
+		return err
+	}
+	names := make([]string, 0, len(schemas))
+	for name := range schemas {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if err := writeInterface(name, schemas[name]); err != nil {
+			return err
+		}
+	}
+	return writeClient(names)
+}
+
+// parseSchemas extracts schema definitions from the limited OpenAPI YAML.
+func parseSchemas(yaml string) (map[string]map[string]string, error) {
+	lines := strings.Split(yaml, "\n")
+	schemas := map[string]map[string]string{}
+	state := 0
+	var currentModel string
+	var currentField string
+	inProperties := false
+	for _, line := range lines {
+		line = strings.TrimRight(line, " ")
+		switch state {
+		case 0:
+			if strings.HasPrefix(line, "components:") {
+				state = 1
+			}
+		case 1:
+			if strings.HasPrefix(line, "  schemas:") {
+				state = 2
+			}
+		case 2:
+			// look for model declarations at indent 4
+			if strings.HasPrefix(line, "    ") && !strings.HasPrefix(line, "      ") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasSuffix(trimmed, ":") {
+					currentModel = strings.TrimSuffix(trimmed, ":")
+					schemas[currentModel] = map[string]string{}
+					inProperties = false
+					currentField = ""
+					continue
+				}
+			}
+			if currentModel == "" {
+				continue
+			}
+			if !inProperties {
+				if strings.HasPrefix(line, "      properties:") {
+					inProperties = true
+				}
+				continue
+			}
+			// inside properties
+			if strings.HasPrefix(line, "        ") && !strings.HasPrefix(line, "          ") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasSuffix(trimmed, ":") {
+					currentField = strings.TrimSuffix(trimmed, ":")
+					continue
+				}
+			}
+			if currentField != "" && strings.Contains(line, "type:") {
+				t := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "type:"))
+				t = strings.Trim(t, "\"")
+				schemas[currentModel][currentField] = t
+				currentField = ""
+				continue
+			}
+			// leaving properties block
+			if strings.HasPrefix(line, "    ") && !strings.HasPrefix(line, "      ") {
+				inProperties = false
+				currentField = ""
+			}
+		}
+	}
+	return schemas, nil
+}
+
+func writeInterface(name string, fields map[string]string) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "export interface %s {\n", name)
+	keys := make([]string, 0, len(fields))
+	for k := range fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(&b, "  %s: %s;\n", k, mapType(fields[k]))
+	}
+	b.WriteString("}\n")
+	file := filepath.Join("generated", "ts", fmt.Sprintf("%s.ts", name))
+	return os.WriteFile(file, []byte(b.String()), 0644)
+}
+
+func writeClient(names []string) error {
+	var b strings.Builder
+	for _, n := range names {
+		fmt.Fprintf(&b, "import { %s } from \"./%s\";\n", n, n)
+	}
+	b.WriteString("\nexport class APIClient {\n  constructor(private baseUrl: string) {}\n")
+	for _, n := range names {
+		lower := strings.ToLower(n)
+		fmt.Fprintf(&b, "  async get%s(id: string): Promise<%s> {\n", n, n)
+		fmt.Fprintf(&b, "    const res = await fetch(`${this.baseUrl}/%s/${id}`);\n", lower)
+		b.WriteString("    if (!res.ok) {\n      throw new Error(res.statusText);\n    }\n")
+		b.WriteString("    return res.json();\n  }\n")
+	}
+	b.WriteString("}\n")
+	file := filepath.Join("generated", "ts", "client.ts")
+	return os.WriteFile(file, []byte(b.String()), 0644)
+}
+
+func mapType(t string) string {
+	switch t {
+	case "integer", "number":
+		return "number"
+	case "boolean":
+		return "boolean"
+	default:
+		return "string"
+	}
+}

--- a/tsgen/tsgen_test.go
+++ b/tsgen/tsgen_test.go
@@ -1,0 +1,53 @@
+package tsgen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerate(t *testing.T) {
+	spec := `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0.0"
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        age:
+          type: integer
+      required: [id, age]
+`
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "spec.yaml")
+	if err := os.WriteFile(specPath, []byte(spec), 0644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	if err := Generate(specPath); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	iface, err := os.ReadFile(filepath.Join(dir, "generated/ts/User.ts"))
+	if err != nil {
+		t.Fatalf("read interface: %v", err)
+	}
+	if !strings.Contains(string(iface), "export interface User") {
+		t.Fatalf("interface not generated: %s", string(iface))
+	}
+	client, err := os.ReadFile(filepath.Join(dir, "generated/ts/client.ts"))
+	if err != nil {
+		t.Fatalf("read client: %v", err)
+	}
+	if !strings.Contains(string(client), "class APIClient") {
+		t.Fatalf("client not generated: %s", string(client))
+	}
+}


### PR DESCRIPTION
## Summary
- add tsgen package that turns OpenAPI YAML into TypeScript interfaces and fetch-based client stub
- expose `cloudpact gen ts <spec.yaml>` CLI entry to run generator

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f79ac4fb48320806e1b66da747328