### PR TITLE
chore: set Go version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/daveroberts0321/cloudpact
 
-go 1.24.3
+go 1.22
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0


### PR DESCRIPTION
## Summary
- set module go version to a supported major.minor

## Testing
- `go mod tidy` *(fails: gopkg.in/check.v1: Forbidden)*
- `go test ./...` *(fails: package cloudpact/parser/grammar is not in std)*

------
https://chatgpt.com/codex/tasks/task_e_688fa44dc79c8320b3c7cb25721b0c07