### PR TITLE
Add project scaffolding templates

### DIFF
--- a/cmd/cloudpact/main.go
+++ b/cmd/cloudpact/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
-//go:embed templates/*
+//go:embed templates/* templates/.gitignore templates/go.mod.tmpl
 var templates embed.FS
 
 // ProjectConfig holds the configuration for a CloudPact project
@@ -219,9 +219,9 @@ func initProject(name string) error {
 		"services/user_service.cp": "templates/user_service.cp",
 		"web/index.html":           "templates/index.html",
 		"web/main.ts":              "templates/main.ts",
-		"go.mod":                   "templates/go.mod",
+		"go.mod":                   "templates/go.mod.tmpl",
 		"README.md":                "templates/README.md",
-		".gitignore":               "templates/gitignore",
+		".gitignore":               "templates/.gitignore",
 	}
 
 	for filePath, templatePath := range templateFiles {

--- a/cmd/cloudpact/templates/.gitignore
+++ b/cmd/cloudpact/templates/.gitignore
@@ -1,0 +1,6 @@
+# CloudPact project
+node_modules/
+dist/
+generated/
+cmd/ai-integration/cache/
+

--- a/cmd/cloudpact/templates/cloudpact.yaml
+++ b/cmd/cloudpact/templates/cloudpact.yaml
@@ -1,0 +1,14 @@
+name: {{.ProjectName}}
+version: 0.1.0
+go_module: {{.ModuleName}}
+port: 8080
+watch_paths:
+  - models
+  - services
+
+api:
+  title: {{.ProjectName}} API
+  version: 0.1.0
+  description: Generated API from CloudPact models
+  server_url: http://localhost:8080
+

--- a/cmd/cloudpact/templates/go.mod.tmpl
+++ b/cmd/cloudpact/templates/go.mod.tmpl
@@ -1,0 +1,4 @@
+module {{.ModuleName}}
+
+go 1.24.3
+

--- a/cmd/cloudpact/templates/main.ts
+++ b/cmd/cloudpact/templates/main.ts
@@ -1,0 +1,12 @@
+interface User {
+    id: string;
+    name: string;
+    email: string;
+}
+
+function init(): void {
+    console.log('CloudPact frontend for {{.ProjectName}} loaded');
+}
+
+document.addEventListener('DOMContentLoaded', init);
+

--- a/cmd/cloudpact/templates/user.cp
+++ b/cmd/cloudpact/templates/user.cp
@@ -1,0 +1,9 @@
+module {{.ProjectName}}Model
+
+define record User
+    id: uuid
+    name: text
+    email: email
+    age: number
+    createdAt: datetime
+

--- a/cmd/cloudpact/templates/user_service.cp
+++ b/cmd/cloudpact/templates/user_service.cp
@@ -1,13 +1,10 @@
 module {{.ProjectName}}Service
 
-define record User
-    name: text
-    email: text
-    age: number
-
 function validateUser(user: User) returns boolean
+    ai-feedback: "Consider adding additional validation"
     why: "Ensures user data meets basic requirements"
     do:
         if user.age < 18
             then return false
         return true
+


### PR DESCRIPTION
## Summary
- add CloudPact project scaffolding templates (user model, service, config, frontend, module and gitignore)
- embed new templates and adjust initProject to reference them

## Testing
- `go test ./...` *(fails: package cloudpact/parser/grammar is not in std; TestParseFieldsAndTypes mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688fa453f5f483209bcdf757de838dc3